### PR TITLE
Updated Kotlin build.gradle dependency description

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ Espresso.registerIdlingResources(resource);
 
 Download
 --------
-
+Groovy
 ```groovy
 androidTestCompile 'com.jakewharton.espresso:okhttp3-idling-resource:1.0.0'
+```
+
+Kotlin
+```kotlin
+androidTestImplementation 'com.jakewharton.espresso:okhttp3-idling-resource:1.0.0'
 ```
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].


### PR DESCRIPTION
Separated the two different dependencies. The groovy and kotlin downloads are different.

See Issue#21: https://github.com/JakeWharton/okhttp-idling-resource/issues/21